### PR TITLE
length fix & resize [experimental branch]

### DIFF
--- a/src/BinaryStream.js
+++ b/src/BinaryStream.js
@@ -94,10 +94,14 @@ class BinaryStream {
 	 * @param {Buffer} buf 
 	 */
 	write(buf, length = -1) {
-		let copyLength = length == -1 ? buf.length : length;
-		this.resize(copyLength);
-		buf.copy(this.buffer, this.writerOffset, 0, copyLength);
-		this.writerOffset += copyLength;
+		const bufferLen = this.buffer.length;
+		const newSize = this.writerOffset + sizeToAdd;
+		this.length += sizeToAdd;
+		if (newSize > bufferLen) {
+			let buf = Buffer.allocUnsafe(Math.max(bufferLen * 2, newSize));
+			this.buffer.copy(buf);
+			this.buffer = buf;
+		}
 	}
 
 	/**

--- a/src/BinaryStream.js
+++ b/src/BinaryStream.js
@@ -44,9 +44,8 @@ class BinaryStream {
 		this.buffer = buffer;
 		this.readerOffset = readerOffset;
 		this.writerOffset = writerOffset;
-		if (length === -1) {
-			this.length = buffer.length;
-		}
+		const bufferLen = buffer.length;
+		this.length = length === -1 ? bufferLen : (length > bufferLen ? bufferLen : (length < 0 ? bufferLen : length));
 	}
 
 	/**

--- a/src/BinaryStream.js
+++ b/src/BinaryStream.js
@@ -41,11 +41,11 @@ class BinaryStream {
 	 * @param {number} offset 
 	 */
 	constructor(buffer = Buffer.allocUnsafe(0), readerOffset = 0, writerOffset = 0, length = -1) {
-		this.buffer = buffer;
-		this.readerOffset = readerOffset;
-		this.writerOffset = writerOffset;
 		const bufferLen = buffer.length;
 		this.length = length === -1 ? bufferLen : (length > bufferLen ? bufferLen : (length < 0 ? bufferLen : length));
+		this.buffer = this.length != bufferLen ? buffer.slice(0, this.length) : buffer;
+		this.readerOffset = readerOffset;
+		this.writerOffset = writerOffset;
 	}
 
 	/**

--- a/src/BinaryStream.js
+++ b/src/BinaryStream.js
@@ -70,10 +70,11 @@ class BinaryStream {
 	 * @param {Number} sizeToAdd
 	 */
 	resize(sizeToAdd) {
-		let newSize = this.readerOffset + sizeToAdd;
-		this.length += newSize;
-		if ((this.buffer.length - newSize) < 0) {
-			let buf = Buffer.allocUnsafe(this.buffer.length + (Math.ceil(newSize / 500) * 500));
+		const bufferLen = this.buffer.length;
+		const newSize = this.writerOffset + sizeToAdd;
+		this.length += sizeToAdd;
+		if (newSize > bufferLen) {
+			let buf = Buffer.allocUnsafe(Math.max(bufferLen * 2, newSize));
 			this.buffer.copy(buf);
 			this.buffer = buf;
 		}
@@ -94,14 +95,10 @@ class BinaryStream {
 	 * @param {Buffer} buf 
 	 */
 	write(buf, length = -1) {
-		const bufferLen = this.buffer.length;
-		const newSize = this.writerOffset + sizeToAdd;
-		this.length += sizeToAdd;
-		if (newSize > bufferLen) {
-			let buf = Buffer.allocUnsafe(Math.max(bufferLen * 2, newSize));
-			this.buffer.copy(buf);
-			this.buffer = buf;
-		}
+		let copyLength = length == -1 ? buf.length : length;
+		this.resize(copyLength);
+		buf.copy(this.buffer, this.writerOffset, 0, copyLength);
+		this.writerOffset += copyLength;
 	}
 
 	/**

--- a/src/BinaryStream.js
+++ b/src/BinaryStream.js
@@ -43,7 +43,7 @@ class BinaryStream {
 	constructor(buffer = Buffer.allocUnsafe(0), readerOffset = 0, writerOffset = 0, length = -1) {
 		const bufferLen = buffer.length;
 		this.length = length === -1 ? bufferLen : (length > bufferLen ? bufferLen : (length < 0 ? bufferLen : length));
-		this.buffer = this.length != bufferLen ? buffer.slice(0, this.length) : buffer;
+		this.buffer = this.length !== bufferLen ? buffer.slice(0, this.length) : buffer;
 		this.readerOffset = readerOffset;
 		this.writerOffset = writerOffset;
 	}


### PR DESCRIPTION
fix the length setter so it isn't undefined when another length is specified

_______________________

fixed resize

try this code without my changes:

```js
const BinaryStream = require("bbmc-binarystream");

let stream = new BinaryStream();

let bufferToWrite = Buffer.allocUnsafe(244);
for (let i = 0; i < 244; ++i) {
    bufferToWrite.writeUInt8(i + 1, i);
}

for (let i = 0; i < 450; ++i) {
	stream.write(bufferToWrite);
}

stream.readerOffset = stream.length - 244;

for (let i = 0; i < 244; ++i) {
	console.log(stream.readUnsignedByte());
}
```

Output:
```
node:internal/buffer:88
  throw new ERR_OUT_OF_RANGE(type || 'offset',
  ^

RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 499. Received 109556
    at new NodeError (node:internal/errors:405:5)
    at boundsError (node:internal/buffer:88:9)
    at Buffer.readUInt8 (node:internal/buffer:254:5)
    at BinaryStream.readUnsignedByte (/home/vp817/Desktop/BBMC-RakNet/node_modules/bbmc-binarystream/src/BinaryStream.js:117:22)
    at Object.<anonymous> (/home/vp817/Desktop/BBMC-RakNet/test.js:17:21)
    at Module._compile (node:internal/modules/cjs/loader:1356:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
    at Module.load (node:internal/modules/cjs/loader:1197:32)
    at Module._load (node:internal/modules/cjs/loader:1013:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12) {
  code: 'ERR_OUT_OF_RANGE'
}

Node.js v18.19.0
```

and try it with my changes

once you do that's the output:
```
1 to 244 ( i don't want to put the log from 1 to 244 because it will make this long)
```

and if you try with my changes this:
```js
stream.readerOffset = stream.length;
```

you can then `stream.readUnsignedByte()` and see that you don't get values between 1-244 and that is not a bug because that's random values behaviour same as before(because unsafe alloc) but that just means that `stream.length` is same as the bytes you wrote

the way to get the data with no such things can be done by slicing the buffer:
```js
const buffer_no_resize_values = stream.buffer.slice(0, stream.length);

// you can now create a new stream  if you want and it doesn't contain the resize values
const stream = new BinaryStream(buffer_no_resize_values);
```
